### PR TITLE
Buscar pedidos con sudo

### DIFF
--- a/static/src/js/pos_guardar.js
+++ b/static/src/js/pos_guardar.js
@@ -956,8 +956,8 @@ floors.TableWidget.include({
         var self = this;
         rpc.query({
                 model: 'pos.order',
-                method: 'search_read',
-                args: [[['table_id', '=', self.table.id ],['state', '=', 'draft']], ['id','customer_count']],
+                method: 'buscar_pedidos',
+                args: [[],[[['table_id', '=', self.table.id ],['state', '=', 'draft']]],[['id', 'customer_count']]],
             })
             .then(function (ordenes){
                 var cantidad_clientes = 0;


### PR DESCRIPTION
Se cambió de funcion search_read a buscar_pedidos que ya estaba creada, se necesitaba hacer la busqueda con sudo, por que no encontraba ningún pedido